### PR TITLE
add rkChainSetJointMotorSetInputAll()

### DIFF
--- a/example/chain/fd_id_test.c
+++ b/example/chain/fd_id_test.c
@@ -1,0 +1,42 @@
+#include <roki/roki.h>
+
+/* this sample will succeed when the model have trq controled motors */
+int main()
+{
+    rkChain chain;
+    
+    rkChainReadZTK(&chain, "../model/arm_2DoF_trq.ztk");
+    rkChainABIAlloc(&chain);
+    zVec dis = zVecAlloc(rkChainJointSize(&chain));
+    zVec vel = zVecAlloc(rkChainJointSize(&chain));
+    zVec acc = zVecAlloc(rkChainJointSize(&chain));
+    zVec expected = zVecAlloc(rkChainJointSize(&chain));
+    zVec actual = zVecAlloc(rkChainJointSize(&chain));
+    zVec err = zVecAlloc(rkChainJointSize(&chain));
+    zVecRandUniform(dis, 10, -10);
+    zVecRandUniform(vel, 10, -10);
+    zVecRandUniform(expected, 10, -10);
+
+    /* FD */
+    /* joint accelaration calculated by abi method */
+    rkChainSetJointMotorSetInputAll(&chain, expected);
+    zVecPrint(rkChainGetJointTrqAll(&chain, actual));
+    rkChainABI(&chain, dis, vel, acc);
+
+    /* ID */
+    /* joint trq calculated by inverse dynamics */
+    rkChainFK(&chain, dis);
+    rkChainID(&chain, vel, acc);
+    rkChainGetJointTrqAll(&chain, actual);
+
+    zVecSub(actual, expected, err);
+    if (zVecIsTiny(err))
+        printf("success\n");
+    else
+        printf("failed\n");
+
+    rkChainABIDestroy(&chain);
+    rkChainDestroy(&chain);
+
+    return 0;
+}

--- a/include/roki/rk_chain.h
+++ b/include/roki/rk_chain.h
@@ -216,6 +216,7 @@ __EXPORT int rkChainJointIndexSize(rkChain *c, zIndex idx);
 #define rkChainLinkSetJointDisCNT(r,i,d,t) rkLinkSetJointDisCNT( rkChainLink(r,i), d, t )
 #define rkChainLinkSetJointVel(r,i,v)      rkLinkSetJointVel( rkChainLink(r,i), v )
 #define rkChainLinkSetJointAcc(r,i,a)      rkLinkSetJointAcc( rkChainLink(r,i), a )
+#define rkChainLinkSetJointMotorSetInput(r,i,t)      rkLinkSetJointMotorSetInput( rkChainLink(r,i), t )
 #define rkChainLinkGetJointDis(r,i,d)      rkLinkGetJointDis( rkChainLink(r,i), d )
 #define rkChainLinkGetJointVel(r,i,v)      rkLinkGetJointVel( rkChainLink(r,i), v )
 #define rkChainLinkGetJointAcc(r,i,a)      rkLinkGetJointAcc( rkChainLink(r,i), a )
@@ -236,6 +237,7 @@ __EXPORT void rkChainSetJointDisCNTAll(rkChain *c, zVec dis, double dt);
 __EXPORT void rkChainSetJointVelAll(rkChain *c, zVec vel);
 __EXPORT void rkChainSetJointAccAll(rkChain *c, zVec acc);
 __EXPORT void rkChainSetJointRateAll(rkChain *c, zVec vel, zVec acc);
+__EXPORT void rkChainSetJointMotorSetInputAll(rkChain *c, zVec trq);
 __EXPORT zVec rkChainGetJointDisAll(rkChain *c, zVec dis);
 __EXPORT zVec rkChainGetJointVelAll(rkChain *c, zVec vel);
 __EXPORT zVec rkChainGetJointAccAll(rkChain *c, zVec acc);

--- a/include/roki/rk_link.h
+++ b/include/roki/rk_link.h
@@ -297,6 +297,7 @@ __EXPORT zMat3D *rkLinkWldInertia(rkLink *l, zMat3D *i);
 #define rkLinkSetJointAcc(l,a)      rkJointSetAcc( rkLinkJoint(l), a )
 #define rkLinkSetJointMin(l,m)      rkJointSetMin( rkLinkJoint(l), m )
 #define rkLinkSetJointMax(l,m)      rkJointSetMax( rkLinkJoint(l), m )
+#define rkLinkSetJointMotorSetInput(l,t)      rkJointMotorSetInput( rkLinkJoint(l), t )
 #define rkLinkSetJointDisCNT(l,d,t) rkJointSetDisCNT( rkLinkJoint(l), d, t )
 #define rkLinkGetJointDis(l,d)      rkJointGetDis( rkLinkJoint(l), d )
 #define rkLinkGetJointVel(l,v)      rkJointGetVel( rkLinkJoint(l), v )

--- a/src/rk_chain.c
+++ b/src/rk_chain.c
@@ -319,6 +319,18 @@ void rkChainSetJointRateAll(rkChain *c, zVec vel, zVec acc)
     }
 }
 
+/* set all joint motor trq of a kinematic chain. */
+void rkChainSetJointMotorSetInputAll(rkChain *c, zVec trq)
+{
+  register int i;
+
+  for( i=0; i<rkChainLinkNum(c); i++ )
+    if( rkChainLinkOffset(c,i) >= 0 ){
+      rkChainLinkSetJointMotorSetInput(c,i,&zVecElemNC(trq,rkChainLinkOffset(c,i)));
+    }
+}
+
+
 /* get all joint displacements of a kinematic chain. */
 zVec rkChainGetJointDisAll(rkChain *c, zVec dis)
 {


### PR DESCRIPTION
Add rkChainSetJointMotorSetInputAll() to calculate forward dynamics: calculation from trq to acc for trq controled robot.
Could you see `example/chain/fd_id_test.c` to share when it will be used.