### PR TITLE
separate bias calculation method from inertia calculation method.

### DIFF
--- a/include/roki/rk_chain.h
+++ b/include/roki/rk_chain.h
@@ -257,6 +257,10 @@ __EXPORT void rkChainSetMotorInputAll(rkChain *c, zVec trq);
  * velocities and accelerations of the whole links of \a c
  * with respect to the inertia frame.
  *
+ * rkChainUpdateRateZeroGravity() updates the motion rates, namely,
+ * velocities and accelerations of the whole links of \a c
+ * with respect to the inertia frame under zero gravity.
+ *
  * rkChainUpdateForce() computes forces and moments acting
  * to the whole links of \a c.
  * \return
@@ -268,6 +272,7 @@ __EXPORT void rkChainSetMotorInputAll(rkChain *c, zVec trq);
 #define rkChainUpdateVel(c)    rkLinkUpdateVel( rkChainRoot(c), ZVEC6DZERO )
 #define rkChainUpdateAcc(c)    rkLinkUpdateAcc( rkChainRoot(c), ZVEC6DZERO, RK_GRAVITY6D )
 #define rkChainUpdateRate(c)   rkLinkUpdateRate( rkChainRoot(c), ZVEC6DZERO, RK_GRAVITY6D )
+#define rkChainUpdateRateZeroGravity(c)   rkLinkUpdateRate( rkChainRoot(c), ZVEC6DZERO, ZVEC6DZERO )
 #define rkChainUpdateWrench(c) rkLinkUpdateWrench( rkChainRoot(c) )
 
 /*! \brief gravity orientation with respect to the root link.
@@ -423,8 +428,19 @@ __EXPORT double rkChainKE(rkChain *c);
  * rkChainInertiaMatBiasVec() returns the true value if it succeeds to compute
  * the matrix and the vector. If the sizes of the given matrix and vector do not
  * match the total degree of freedom of the chain, the false value is returned.
+ * 
+ * rkChainInertiaMat() returns the true value if it succeeds to compute
+ * the matrix and the vector. If the sizes of the given matrix does not
+ * match the total degree of freedom of the chain, the false value is returned.
+ * 
+ * rkChainBiasVec() returns the true value if it succeeds to compute
+ * the matrix and the vector. If the sizes of the given vector does not
+ * match the total degree of freedom of the chain, the false value is returned.
  */
 __EXPORT bool rkChainInertiaMatBiasVec(rkChain *chain, zMat inertia, zVec bias);
+__EXPORT bool rkChainInertiaMat(rkChain *chain, zMat inertia);
+__EXPORT bool rkChainBiasVec(rkChain *chain, zVec bias);
+
 
 /*! \brief external force applied to kinematic chain.
  *

--- a/test/chain_test.c
+++ b/test/chain_test.c
@@ -142,20 +142,22 @@ int chain_init(rkChain *chain)
 int main(int argc, char *argv[])
 {
   rkChain chain;
-  zMat h;
-  zVec b, dis, vel;
-  int i, count_im, count_ke, count_fd;
+  zMat h, hs;
+  zVec b, bs, dis, vel;
+  int i, count_im, count_ke, count_fd, count_sep;
   int n;
 
   /* initialization */
   zRandInit();
   n = chain_init( &chain );
   h = zMatAllocSqr( n );
+  hs= zMatAllocSqr( n );
   dis = zVecAlloc( n );
   vel = zVecAlloc( n );
   b = zVecAlloc( n );
+  bs = zVecAlloc( n );
 
-  count_im = count_ke = count_fd = 0;
+  count_im = count_ke = count_fd = count_sep = 0;
   for( i=0; i<N; i++ ){
     /* generate posture and velocity randomly */
     zVecRandUniform( dis, -10, 10 );
@@ -164,17 +166,25 @@ int main(int argc, char *argv[])
     rkChainSetJointVelAll( &chain, vel );
     /* verifications */
     rkChainInertiaMatBiasVec( &chain, h, b );
+    rkChainBiasVec( &chain, bs );
+    rkChainInertiaMat( &chain, hs );/* joint vel to be zero */
+    /* restore joint velocity */
+    rkChainSetJointVelAll( &chain, vel );
+    rkChainUpdateRate(&chain);
+    /* count success */
     if( check_inertia_matrix( &chain, h, TOL ) ) count_im++;
     if( check_kinetic_energy( &chain, h, vel, TOL ) ) count_ke++;
     if( check_fd( &chain, h, b, vel, TOL ) ) count_fd++;
+    if( zMatIsEqual(h, hs, TOL) && zVecIsEqual(b, bs, TOL)) count_sep++;
   }
   zAssert( rkChainInertiaMatBiasVec, count_im == N );
   zAssert( rkChainInertiaMatBiasVec + rkChainKE, count_ke == N );
   zAssert( rkChainInertiaMatBiasVec (FD-ID), count_fd == N );
+  zAssert( rkChainBiasVec/rkChainInertiaMat, count_sep == N );
 
   /* termination */
-  zMatFree( h );
-  zVecFreeAO( 3, b, dis, vel );
+  zMatFreeAO( 2, h, hs);
+  zVecFreeAO( 4, b, bs, dis, vel );
   rkChainDestroy( &chain );
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
- I have separated bias calculation method from inertia calculation method by using ID method under zero gravity. The inertia calculation method is formulated by the following equation.
   $$\mathbf{M}\mathbf{u}+\mathbf{C}\mathbf{0}+\mathbf{0} = \mathbf{\tau}$$
- rkChainUpdateRateZeroGravity or equivalent method may be defined in roki-fd.( @n-wakisaka )