### PR TITLE
Fix chain2vert_test to rename zBBall3DPL -> zBoundingBall3DPL

### DIFF
--- a/example/chain/chain2vert_test.c
+++ b/example/chain/chain2vert_test.c
@@ -9,7 +9,7 @@ int main(int argc, char *argv[])
   rkChainReadZTK( &chain, "../model/mighty.ztk" );
   rkChainVertList( &chain, &vl );
   zVec3DListDataPrint( &vl );
-  zBBall3DPL( &bb, &vl, NULL );
+  zBoundingBall3DPL( &bb, &vl, NULL );
   zSphere3DFPrintZTK( stderr, &bb );
 
   zVec3DListDestroy( &vl );


### PR DESCRIPTION
As the title suggests, 
there was an error in the function name ( zBBall3DPL -> zBoundingBall3DPL ) in the sample roki/example/chain/chain2vert_test.c, 
so I fixed it.

Please check and merge.