### PR TITLE
Delete abolished macros rkGravitySet and rkGravityReset in gravity_test

### DIFF
--- a/example/body/gravity_test.c
+++ b/example/body/gravity_test.c
@@ -6,14 +6,5 @@ int main(void)
   zVec6DPrint( RK_GRAVITY6D );
   zVec3DPrint( RK_GRAVITY3D );
 
-  printf( "+++ clear gravity +++\n" );
-  rkGravitySet( 0 );
-  zVec6DPrint( RK_GRAVITY6D );
-  zVec3DPrint( RK_GRAVITY3D );
-
-  printf( "+++ reset gravity +++\n" );
-  rkGravityReset();
-  zVec6DPrint( RK_GRAVITY6D );
-  zVec3DPrint( RK_GRAVITY3D );
   return 0;
 }


### PR DESCRIPTION
As the title says. Fixed one bug in the sample code.
Please check.